### PR TITLE
Can disable identity client

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -136,7 +136,6 @@ $ussfAuth = new UssfAuth(
        auth0: null, // Can specify our own Auth0 instance; leave `null` to create from `auth0Configuration`
        logger: new StdoutLogger(), // Can specify your own PSR/log-compatible logger, such as Monolog
    ),
-   identity: new IdentityClient(new IdentityClientConfiguration()),
 );
 ```
 
@@ -260,7 +259,6 @@ class SoccerIdServiceProvider extends ServiceProvider
                         auth0Configuration: $configuration,
                         logger: $logger,
                     ),
-                    identity: new IdentityClient(new IdentityClientConfiguration()),
                 );
             }
         );

--- a/example/init.php
+++ b/example/init.php
@@ -39,7 +39,6 @@ function getUssfAuth(): UssfAuth
                 auth0: null, // Can specify our own Auth0 instance; leave `null` to create from `auth0Configuration`
                 logger: new StdoutLogger(), // Can specify your own PSR/log-compatible logger, such as Monolog
             ),
-            identity: new IdentityClient(new IdentityClientConfiguration()),
         );
     }
 

--- a/src/UssfAuth.php
+++ b/src/UssfAuth.php
@@ -14,7 +14,7 @@ class UssfAuth
 {
     public function __construct(
         protected Auth0Client $auth0,
-        protected IdentityClient $identity
+        protected ?IdentityClient $identity = null
     ) {
     }
 
@@ -58,10 +58,10 @@ class UssfAuth
         $session = $this->auth0->callback();
 
         if ($callback !== null) {
-            $profile = $this->identity->getProfile($session->accessToken);
+            $profile = $this->identity?->getProfile($session->accessToken);
             $updates = $callback($session, $profile);
 
-            if (is_array($updates) || is_object($updates)) {
+            if ($profile !== null && (is_array($updates) || is_object($updates))) {
                 $this->identity->updateProfile($session->accessToken, $updates);
             }
         }
@@ -72,9 +72,9 @@ class UssfAuth
     /**
      * Returns the instance of the Identity Service client.
      * You may use this to get/update the user's profile manually instead of using a closure in `callback()`
-     * @return IdentityClient
+     * @return ?IdentityClient
      */
-    public function identity(): IdentityClient
+    public function identity(): ?IdentityClient
     {
         return $this->identity;
     }

--- a/tests/Feature/UssfAuthTest.php
+++ b/tests/Feature/UssfAuthTest.php
@@ -59,3 +59,35 @@ test('can complete callback and sync profile', function () {
     expect($receivedIdToken)->toBe('test-id-token');
     expect($receivedTestToken)->toBe('test-value');
 });
+
+test('can function without IdentityClient', function () {
+    $mockAuth0Client = Mockery::mock(Auth0Client::class)->makePartial();
+    $mockAuth0Client->allows('callback')->andReturn(
+        Auth0Session::fromStdObject(
+            (object)[
+                'user' => [],
+                'idToken' => 'test-id-token',
+                'accessToken' => '',
+                'accessTokenScope' => [],
+                'accessTokenExpiration' => 1_000_000,
+                'accessTokenExpired' => false,
+                'refreshToken' => null,
+                'backchannel' => '',
+            ]
+        )
+    );
+
+    $ussfAuth = new UssfAuth(
+        auth0: $mockAuth0Client,
+        identity: null
+    );
+
+    $ussfAuth->callback(function(Auth0Session $session, ?object $profile) {
+        expect($session->idToken)->toBe('test-id-token');
+        expect($profile)->toBeNull();
+
+        return [
+            'updated' => true, // *shouldn't* actually do anything in this case
+        ];
+    });
+});


### PR DESCRIPTION
- Disabled by default; we'll change this once Identity Service is public
- Make `IdentityClient` nullable
- Cannot get or update profile without `IdentityClient`