### PR TITLE
DP-2577 - Soccer ID PHP SDK - Identity Service update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ APP_URL=
 # the Auth0 exchange.
 USSF_AUTH0_CALLBACK_ROUTE=/callback.php
 
+# If given a specific audience for your application, set it here.
+# For production, you should probably leave this empty to use the default.
+USSF_AUTH0_AUDIENCE=
 
 # (Optional) This should be the route that the user will be sent to
 # after logging out of the app via `UssfAuth::logout()`

--- a/example/callback.php
+++ b/example/callback.php
@@ -15,27 +15,47 @@ include 'init.php';
  * - Set any cookies/session needed to keep the user logged into your app
  */
 
-$session = getUssfAuth()->callback(function (Auth0Session $session, ?object $profile) {
-    // $session will contain information related to Auth0, such as name, email, access token, etc.
-    // $profile will contain additional information about the user. Data shape is configurable.
-    //
-    // This is where you can sync the user's info with your database.
+$session = getUssfAuth()->callback(
+    function (Auth0Session $session, ?object $profile) {
+        // $session will contain information related to Auth0, such as name, email, access token, etc.
+        // $profile will contain additional information about the user. Data shape is configurable.
 
-    // Set the user's session cookies, or whatever else your app needs to do to log in a user.
-    // Ensure that you are
-    session_set_cookie_params([
-        'lifetime' => 3600, // Cookie expires in 1 hour
-        'path' => '/',
-        'domain' => '', // Defaults to the current domain
-        'secure' => false, // Should typically be `true`, but we'll allow HTTP for testing purposes
-        'httponly' => true, // Prevent JavaScript access
-        'samesite' => 'Strict' // Restrict cross-site requests
-    ]);
+        /*
+         * This is where you can sync the user's info with your database.
+         * Example:
+         *
+         * if ($profile === null) {
+         *    DB::table('users')
+         *        ->where('email', $session->user['email'])
+         *        ->update([
+         *            'first_name' => $profile->user_metadata->profile->firstName,
+         *            'last_name' => $profile->user_metadata->profile->lastName
+         *        ]);
+         * }
+         */
 
-    session_start();
-    $_SESSION['logged_in'] = true;
-    $_SESSION['username'] = $session->user['email'];
+        // Set the user's session cookies, or whatever else your app needs to do to log in a user.
+        // Example only; not secure
+        $_SESSION['logged_in'] = true;
+        $_SESSION['username'] = $session->user['email'];
+        $_SESSION['auth0AccessToken'] = $session->accessToken;
 
-    // Direct the user into your application; don't keep them on callback
-    header("Location: /index.php");
-});
+
+        // You may return an array of key-value pairs in order to perform a profile update
+        // to USSF's Identity Service
+        return [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+        ];
+    },
+    // You may pass an array of profile keys to selectively pull only the given profile params.
+    // This will affect the shape of the `$profile` passed to the closure.
+    [
+        'user_metadata.profile.firstName',
+        'user_metadata.profile.lastName',
+        'user_metadata.profile.birthDate'
+    ]
+);
+
+// Direct the user into your application; don't keep them on callback
+header("Location: /index.php");

--- a/example/index.php
+++ b/example/index.php
@@ -1,5 +1,12 @@
 <?php
     include 'init.php';
+
+    $profile = null;
+    if( isset($_SESSION['auth0AccessToken']) ){
+        // Note: It's not recommend that you really live pull this kind of data every page load; you should probably cache it.
+        // This is only here as an example indicating that you can access a user's profile outside of the login callback.
+        $profile = getUssfAuth()->identity()->getProfile($_SESSION['auth0AccessToken']) ?? null;
+    }
 ?>
 <html>
     <head></head>
@@ -9,6 +16,12 @@
         <?php if($_SESSION['logged_in'] ?? false) :?>
             You are logged in as <?php echo htmlspecialchars($_SESSION['username']); ?> &nbsp; | &nbsp;
             <a href="/logout.php">Log out</a>
+
+            <h2 style="margin-top: 4em;">Profile</h2>
+            <strong>Name:</strong> <?php echo htmlspecialchars($profile?->user_metadata->profile->firstName ?? ''); ?>
+            <?php echo htmlspecialchars($profile->user_metadata->profile->lastName ?? ''); ?><br />
+
+            <strong>DOB:</strong> <?php echo htmlspecialchars($profile?->user_metadata->profile->birthDate ?? ''); ?>
         <?php else:?>
             <a href="/login.php">Log in via U.S. Soccer</a>
         <?php endif;?>

--- a/example/init.php
+++ b/example/init.php
@@ -4,8 +4,8 @@
  * Just a simple place to dump reused logic on example scripts.
  */
 
-use USSoccerFederation\UssfAuthSdkPhp\Auth\Auth0Configuration;
 use USSoccerFederation\UssfAuthSdkPhp\Auth\Auth0Client;
+use USSoccerFederation\UssfAuthSdkPhp\Auth\Auth0Configuration;
 use USSoccerFederation\UssfAuthSdkPhp\Identity\IdentityClient;
 use USSoccerFederation\UssfAuthSdkPhp\Identity\IdentityClientConfiguration;
 use USSoccerFederation\UssfAuthSdkPhp\Logging\StdoutLogger;
@@ -24,10 +24,21 @@ if (file_exists("{$envPath}/.env")) {
  * ```
  */
 
+session_start([
+    'cookie_lifetime' => 3600, // Cookie expires in 1 hour
+    'cookie_path' => '/',
+    'cookie_domain' => '', // Defaults to the current domain
+    'cookie_secure' => false, // Should typically be `true`, but we'll allow http:// for testing purposes
+    'cookie_httponly' => true, // Prevent JavaScript access
+    'cookie_samesite' => 'Strict' // Restrict cross-site requests
+]);
+
 function getUssfAuth(): UssfAuth
 {
     static $instance = null;
     if ($instance === null) {
+        $logger = new StdoutLogger(); // Can also specify your own PSR/log-compatible logger, such as Monolog
+
         /*
          * Just an example of how you would bootstrap UssfAuth.
          * In Laravel, you would place this into a Service Provider.
@@ -37,12 +48,14 @@ function getUssfAuth(): UssfAuth
             auth0: new Auth0Client(
                 auth0Configuration: Auth0Configuration::fromEnv(), // Load from environment variables
                 auth0: null, // Can specify our own Auth0 instance; leave `null` to create from `auth0Configuration`
-                logger: new StdoutLogger(), // Can specify your own PSR/log-compatible logger, such as Monolog
+                logger: $logger,
+            ),
+            identity: new IdentityClient(
+                configuration: IdentityClientConfiguration::fromEnv(),
+                logger: $logger
             ),
         );
     }
 
     return $instance;
 }
-
-session_start();

--- a/src/Auth/Auth0Client.php
+++ b/src/Auth/Auth0Client.php
@@ -21,6 +21,8 @@ use USSoccerFederation\UssfAuthSdkPhp\Helpers\Path;
  */
 class Auth0Client
 {
+    const USSF_GATEWAY = 'https://gateway.ussoccer.com';
+
     public function __construct(
         protected Auth0Configuration $auth0Configuration,
         protected ?Auth0Interface $auth0 = null,
@@ -33,6 +35,7 @@ class Auth0Client
 
             $this->auth0 = new Auth0([
                 'domain' => $auth0Configuration->domain,
+                'audience' => $this->auth0Configuration->audience,
                 'clientId' => $auth0Configuration->clientId,
                 'clientSecret' => $auth0Configuration->clientSecret,
                 'cookieSecret' => $auth0Configuration->cookieSecret,

--- a/src/Auth/Auth0Configuration.php
+++ b/src/Auth/Auth0Configuration.php
@@ -12,6 +12,7 @@ class Auth0Configuration
         public string $clientSecret,
         public string $cookieSecret,
         public ?string $baseUrl = null,
+        public array $audience = [Auth0Client::USSF_GATEWAY],
         public string $callbackRoute = '/auth0_callback',
         public string $redirectUri = '/',
     ) {
@@ -33,6 +34,7 @@ class Auth0Configuration
             'Missing USSF_AUTH0_COOKIE_SECRET from ENV'
         ),
             baseUrl: $_ENV['APP_URL'] ?? '',
+            audience: !empty($_ENV['USSF_AUTH0_AUDIENCE']) ? [$_ENV['USSF_AUTH0_AUDIENCE']] : [Auth0Client::USSF_GATEWAY],
             callbackRoute: $_ENV['USSF_AUTH0_CALLBACK_ROUTE'] ?? throw new InvalidArgumentException(
             'Missing USSF_AUTH0_CALLBACK_ROUTE from ENV'
         ),

--- a/src/Identity/IdentityClient.php
+++ b/src/Identity/IdentityClient.php
@@ -40,7 +40,7 @@ class IdentityClient
      * @return object|null Data shape depends on partner configuration.
      * @throws JsonException|ClientExceptionInterface
      */
-    public function getProfile(string $auth0AccessToken, null|array $params = null): ?object
+    public function getProfile(string $auth0AccessToken, ?array $params = null): ?object
     {
         $query = $this->buildQueryString($params);
         $uri = (new Path($this->configuration->baseUrl))
@@ -169,7 +169,7 @@ class IdentityClient
      * @param array|null $params
      * @return string
      */
-    protected function buildQueryString(null|array $params): string
+    protected function buildQueryString(?array $params): string
     {
         // We can't use `http_build_query` here as we key by `fields` but don't use an array
         if (empty($params)) {

--- a/src/Identity/IdentityClient.php
+++ b/src/Identity/IdentityClient.php
@@ -160,6 +160,15 @@ class IdentityClient
         }
     }
 
+    /**
+     * Helps construct the GET parameters.
+     * Cannot simply use `http_build_query()` as it'll format repeated fields as arrays.
+     * For example, we need: fields=a&fields=b&fields=c
+     * http_build_query would return: fields[]=a&fields=b&fields[]=c
+     *
+     * @param array|null $params
+     * @return string
+     */
     protected function buildQueryString(null|array $params): string
     {
         // We can't use `http_build_query` here as we key by `fields` but don't use an array

--- a/src/Identity/IdentityClientConfiguration.php
+++ b/src/Identity/IdentityClientConfiguration.php
@@ -22,4 +22,11 @@ class IdentityClientConfiguration
             $this->requestFactory = Psr17FactoryDiscovery::findRequestFactory();
         }
     }
+
+    public static function fromEnv(): self
+    {
+        return new self(
+            baseUrl: $_ENV['IDENTITY_SERVICE_BASE_URL'] ?? IdentityClient::BASE_API_URL
+        );
+    }
 }

--- a/src/Identity/IdentityClientConfiguration.php
+++ b/src/Identity/IdentityClientConfiguration.php
@@ -26,7 +26,7 @@ class IdentityClientConfiguration
     public static function fromEnv(): self
     {
         return new self(
-            baseUrl: $_ENV['IDENTITY_SERVICE_BASE_URL'] ?? IdentityClient::BASE_API_URL
+            baseUrl: $_ENV['USSF_IDENTITY_SERVICE_BASE_URL'] ?? IdentityClient::BASE_API_URL
         );
     }
 }

--- a/src/Logging/StdoutLogger.php
+++ b/src/Logging/StdoutLogger.php
@@ -29,7 +29,10 @@ class StdoutLogger implements LoggerInterface
         $timestamp = date('Y-m-d H:i:s');
         $contextString = json_encode($context);
 
-        echo sprintf("[%s] %s: %s %s\n", $timestamp, $levelName, $message, $contextString);
+        file_put_contents(
+            'php://stderr',
+            sprintf("[%s] %s: %s %s\n", $timestamp, $levelName, $message, $contextString)
+        );
     }
 
     public function alert($message, array $context = []): void

--- a/src/UssfAuth.php
+++ b/src/UssfAuth.php
@@ -49,16 +49,17 @@ class UssfAuth
      * - Return an array|object of key-value pairs for any profile updates that are needed (ie. update profile)
      *
      * @param Closure|null $callback
+     * @param array|null $profileParams
      * @return Auth0Session
-     * @throws JsonException
      * @throws ClientExceptionInterface
+     * @throws JsonException
      */
-    public function callback(?Closure $callback = null): Auth0Session
+    public function callback(?Closure $callback = null, null|array $profileParams = null): Auth0Session
     {
         $session = $this->auth0->callback();
 
         if ($callback !== null) {
-            $profile = $this->identity?->getProfile($session->accessToken);
+            $profile = $this->identity?->getProfile($session->accessToken, $profileParams);
             $updates = $callback($session, $profile);
 
             if ($profile !== null && (is_array($updates) || is_object($updates))) {

--- a/src/UssfAuth.php
+++ b/src/UssfAuth.php
@@ -54,7 +54,7 @@ class UssfAuth
      * @throws ClientExceptionInterface
      * @throws JsonException
      */
-    public function callback(?Closure $callback = null, null|array $profileParams = null): Auth0Session
+    public function callback(?Closure $callback = null, ?array $profileParams = null): Auth0Session
     {
         $session = $this->auth0->callback();
 


### PR DESCRIPTION
# Do not merge until Identity Service is operational

# Changes
- Improve example - Clarify how to use and update profile data
- Fix included `StdoutLogger` - literally using `stdout` stream would log to browser on a webserver; using `stderr` stream instead to log to console.
- Update base Identity Service base URI
- Specify Auth0 audience; needed to allow access tokens to be accepted by our API gateway
- Can specify profile shaping parameters
- Fix bug that caused requests to _not_ actually include the POST body (was setting the stream, but then discarding the modified object instead of assigning it).